### PR TITLE
Fixed variable scopes

### DIFF
--- a/ssl_logger.py
+++ b/ssl_logger.py
@@ -54,10 +54,17 @@ _FRIDA_SCRIPT = """
   /**
    * Initializes 'addresses' dictionary and NativeFunctions.
    */
+  var addresses = {};
+  var SSL_get_fd;
+  var SSL_get_session;
+  var SSL_SESSION_get_id;
+  var getpeername;
+  var getsockname;
+  var ntohs;
+  var ntohl;
+
   function initializeGlobals()
   {
-    addresses = {};
-
     var resolver = new ApiResolver("module");
 
     var exps = [


### PR DESCRIPTION
Variable scopes in JavaScript may lead to errors when not defined globally.